### PR TITLE
feat: add Spanish language support

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Muktika's 2nd Birthday Party!</title>
+    <title data-en="Muktika's 2nd Birthday Party!">¡Fiesta del 2º cumpleaños de Muktika!</title>
     <link rel="stylesheet" href="styles.css" />
 
     <!-- Favicon -->
@@ -27,10 +27,10 @@
     <link rel="manifest" href="media/site.webmanifest" />
 
     <!-- Social Media Sharing -->
-    <meta property="og:title" content="Muktika's 2nd Birthday Party!" />
+    <meta property="og:title" content="¡Fiesta del 2º cumpleaños de Muktika!" />
     <meta
       property="og:description"
-      content="Please join us to celebrate this special day!"
+      content="¡Únete a nosotros para celebrar este día tan especial!"
     />
     <meta property="og:image" content="media/og-image.jpg" />
     <meta property="og:url" content="https://shubhshackyard.github.io/birthdayInvitation" />
@@ -38,16 +38,16 @@
   <body>
     <div class="container">
       <div class="language-toggle">
-        <button id="toggleLanguage" class="lang-btn">हिंदी</button>
+        <button id="toggleLanguage" class="lang-btn">English</button>
       </div>
 
       <header>
         <div class="balloons">🎈🎀🎈</div>
         <h1
           data-en="Muktika's 2nd Birthday Party!"
-          data-hi="मुक्तिका का दूसरा जन्मदिन!"
+          data-es="¡Fiesta del 2º cumpleaños de Muktika!"
         >
-          Muktika's 2nd Birthday Party!
+          ¡Fiesta del 2º cumpleaños de Muktika!
         </h1>
 
         <div class="video-container">
@@ -83,31 +83,29 @@
 
         <p
           data-en="Please join us to celebrate this special day!"
-          data-hi="कृपया इस विशेष दिन को मनाने के लिए हमारे साथ जुड़ें!"
+          data-es="¡Únete a nosotros para celebrar este día tan especial!"
         >
-          Please join us to celebrate this special day!
+          ¡Únete a nosotros para celebrar este día tan especial!
         </p>
         <div class="balloons">🎁🧸🎂</div>
       </header>
 
       <div class="event-details">
-        <h2 data-en="Party Details" data-hi="पार्टी विवरण">Party Details</h2>
+        <h2 data-en="Party Details" data-es="Detalles de la fiesta">Detalles de la fiesta</h2>
         <p>
-          <strong data-en="Date:" data-hi="दिनांक:">Date:</strong> Monday, Mar
-          24, 2025
+          <strong data-en="Date:" data-es="Fecha:">Fecha:</strong> Lunes, 24 de marzo de 2025
         </p>
         <p>
-          <strong data-en="Time:" data-hi="समय:">Time:</strong> 6:30 PM - 10:00
-          PM
+          <strong data-en="Time:" data-es="Hora:">Hora:</strong> 6:30 PM - 10:00 PM
         </p>
         <p>
-          <strong data-en="Venue:" data-hi="स्थान:">Venue:</strong> R/o
+          <strong data-en="Venue:" data-es="Lugar:">Lugar:</strong> R/o
           Mr. Amar Sonker, ET - 1/A, Combined Hospital Campus, Cantt. Kanpur -
           208001 (Near Jhadi Baba Padav, Sahani Market)
         </p>
 
         <div class="map-container">
-          <h3 data-en="Location Map" data-hi="स्थान मानचित्र">Location Map</h3>
+          <h3 data-en="Location Map" data-es="Mapa de ubicación">Mapa de ubicación</h3>
           <div class="map-wrapper">
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d801.9511838133279!2d80.36721009649466!3d26.467277672967974!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sin!4v1742172448218!5m2!1sen!2sin"
@@ -125,37 +123,37 @@
               target="_blank"
               class="map-btn"
               data-en="Open in Google Maps"
-              data-hi="Google मैप्स में खोलें"
-              >Open in Google Maps</a
+              data-es="Abrir en Google Maps"
+              >Abrir en Google Maps</a
             >
             <button
               class="map-btn toggle-map"
               data-en="Hide Map"
-              data-hi="मानचित्र छिपाएं"
+              data-es="Ocultar mapa"
             >
-              Hide Map
+              Ocultar mapa
             </button>
           </div>
         </div>
 
         <p>
-          <strong data-en="Theme:" data-hi="थीम:">Theme:</strong> Unicorns
+          <strong data-en="Theme:" data-es="Tema:">Tema:</strong> Unicornios
         </p>
         <p
           data-en="Come join the fun as we celebrate with yummy treats, laughter, and wonderful family moments—let’s make sweet memories together!"
-          data-hi="आइए, हम स्वादिष्ट व्यंजनों, हंसी-मजाक और अद्भुत पारिवारिक क्षणों के साथ जश्न मनाएं - आइए, साथ मिलकर मीठी यादें बनाएं!"
+          data-es="¡Ven y únete a la diversión mientras celebramos con deliciosos bocadillos, risas y maravillosos momentos en familia; hagamos dulces recuerdos juntos!"
         >
-        Come join the fun as we celebrate with yummy treats, laughter, and wonderful family moments—let’s make sweet memories together!
+        ¡Ven y únete a la diversión mientras celebramos con deliciosos bocadillos, risas y maravillosos momentos en familia; hagamos dulces recuerdos juntos!
         </p>
       </div>
 
       <div class="form-container">
-        <h2 data-en="RSVP" data-hi="आर.एस.वी.पी.">RSVP</h2>
+        <h2 data-en="RSVP" data-es="Confirmación de asistencia">Confirmación de asistencia</h2>
         <!-- <p
           data-en="Please let us know if you can attend by March 20th."
-          data-hi="कृपया हमें 20 मार्च तक बताएं कि क्या आप आ सकते हैं।"
+          data-es="Por favor avísanos si puedes asistir antes del 20 de marzo."
         >
-          Please let us know if you can attend by March 20th.
+          Por favor avísanos si puedes asistir antes del 20 de marzo.
         </p> -->
 
         <form
@@ -176,15 +174,15 @@
           />
 
           <div class="form-group">
-            <label for="name" data-en="Your Name:" data-hi="आपका नाम:"
-              >Your Name:</label
+            <label for="name" data-en="Your Name:" data-es="Tu nombre:"
+              >Tu nombre:</label
             >
             <input type="text" id="name" name="name" required />
           </div>
 
           <div class="form-group">
-            <label data-en="Will you attend?" data-hi="क्या आप आएंगे?"
-              >Will you attend?</label
+            <label data-en="Will you attend?" data-es="¿Asistirás?"
+              >¿Asistirás?</label
             >
             <div class="radio-options">
               <div class="radio-option">
@@ -198,8 +196,8 @@
                 <label
                   for="attend-yes"
                   data-en="Yes, we'll be there!"
-                  data-hi="हां, हम आएंगे!"
-                  >Yes, we'll be there!</label
+                  data-es="¡Sí, estaremos allí!"
+                  >¡Sí, estaremos allí!</label
                 >
               </div>
               <div class="radio-option">
@@ -212,8 +210,8 @@
                 <label
                   for="attend-no"
                   data-en="Sorry, we can't make it"
-                  data-hi="माफ़ करें, हम नहीं आ सकते"
-                  >Sorry, we can't make it</label
+                  data-es="Lo sentimos, no podremos asistir"
+                  >Lo sentimos, no podremos asistir</label
                 >
               </div>
             </div>
@@ -223,8 +221,8 @@
             <label
               for="guests"
               data-en="Number of guests (including yourself):"
-              data-hi="अतिथियों की संख्या (स्वयं सहित):"
-              >Number of guests (including yourself):</label
+              data-es="Número de invitados (incluyéndote):"
+              >Número de invitados (incluyéndote):</label
             >
             <input
               type="number"
@@ -246,8 +244,8 @@
             <label
               for="allergies"
               data-en="Any allergies or dietary restrictions?"
-              data-hi="कोई एलर्जी या आहार संबंधी प्रतिबंध?"
-              >Any allergies or dietary restrictions?</label
+              data-es="¿Alguna alergia o restricción alimentaria?"
+              >¿Alguna alergia o restricción alimentaria?</label
             >
             <textarea id="allergies" name="allergies" rows="3"></textarea>
           </div>
@@ -256,8 +254,8 @@
             <label
               for="message"
               data-en="Message for Muktika (optional):"
-              data-hi="मुक्तिका के लिए संदेश (वैकल्पिक):"
-              >Message for Muktika (optional):</label
+              data-es="Mensaje para Muktika (opcional):"
+              >Mensaje para Muktika (opcional):</label
             >
             <textarea id="message" name="message" rows="3"></textarea>
           </div>
@@ -265,9 +263,9 @@
           <button
             type="submit"
             data-en="Submit RSVP"
-            data-hi="आर.एस.वी.पी. जमा करें"
+            data-es="Enviar RSVP"
           >
-            Submit RSVP
+            Enviar RSVP
           </button>
 
         </form>
@@ -277,9 +275,9 @@
           class="success-message"
           style="display: none"
           data-en="Thank you for your response! We look forward to celebrating with you."
-          data-hi="आपके जवाब के लिए धन्यवाद! हम आपके साथ जश्न मनाने के लिए उत्सुक हैं।"
+          data-es="¡Gracias por tu respuesta! Esperamos celebrar contigo."
         >
-          Thank you for your response! We look forward to celebrating with you.
+          ¡Gracias por tu respuesta! Esperamos celebrar contigo.
         </div>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -1,13 +1,13 @@
 // Language toggle functionality
-let currentLanguage = 'en';
+let currentLanguage = 'es';
 
 document.getElementById('toggleLanguage').addEventListener('click', function() {
-    if (currentLanguage === 'en') {
-        switchLanguage('hi');
-        this.textContent = 'English';
-    } else {
+    if (currentLanguage === 'es') {
         switchLanguage('en');
-        this.textContent = 'हिंदी';
+        this.textContent = 'Español';
+    } else {
+        switchLanguage('es');
+        this.textContent = 'English';
     }
 });
 
@@ -59,7 +59,7 @@ document.getElementById('rsvpForm').addEventListener('submit', function(event) {
     } else {
         // For initial form submission
         const submitButton = document.querySelector('button[type="submit"]');
-        submitButton.textContent = currentLanguage === 'en' ? 'Submitting...' : 'भेज रहा है...';
+        submitButton.textContent = currentLanguage === 'en' ? 'Submitting...' : 'Enviando...';
         submitButton.disabled = true;
         
         // Save local backup
@@ -148,7 +148,7 @@ function updateMapToggleText(button, isCollapsed) {
     if (currentLanguage === 'en') {
         button.textContent = isCollapsed ? 'Show Map' : 'Hide Map';
     } else {
-        button.textContent = isCollapsed ? 'मानचित्र दिखाएं' : 'मानचित्र छिपाएं';
+        button.textContent = isCollapsed ? 'Mostrar mapa' : 'Ocultar mapa';
     }
 }
 
@@ -194,9 +194,9 @@ document.querySelectorAll('input[name="attendance"]').forEach(function(radio) {
 // Handle dynamic guest details generation
 document.getElementById('guests').addEventListener('change', function() {
     generateGuestFields(parseInt(this.value) || 1);
-    
+
     // Apply language to new elements
-    if (currentLanguage !== 'en') {
+    if (currentLanguage !== 'es') {
         switchLanguage(currentLanguage);
     }
 });
@@ -211,22 +211,22 @@ function generateGuestFields(count) {
         guestDiv.className = 'guest-detail';
         guestDiv.dataset.guestIndex = i;
         
-        const title = i === 1 ? 
-            `<h4 data-en="Guest ${i} (you)" data-hi="अतिथि ${i} (आप)">Guest ${i} (you)</h4>` : 
-            `<h4 data-en="Guest ${i}" data-hi="अतिथि ${i}">Guest ${i}</h4>`;
-        
+        const title = i === 1 ?
+            `<h4 data-en="Guest ${i} (you)" data-es="Invitado ${i} (tú)">Invitado ${i} (tú)</h4>` :
+            `<h4 data-en="Guest ${i}" data-es="Invitado ${i}">Invitado ${i}</h4>`;
+
         guestDiv.innerHTML = `
             ${title}
             <div class="form-group">
-                <label for="guestName${i}" data-en="Name:" data-hi="नाम:">Name:</label>
+                <label for="guestName${i}" data-en="Name:" data-es="Nombre:">Nombre:</label>
                 <input type="text" id="guestName${i}" name="guestName${i}" required>
             </div>
             <div class="form-group">
-                <label for="guestMeal${i}" data-en="Meal Preference:" data-hi="भोजन प्राथमिकता:">Meal Preference:</label>
+                <label for="guestMeal${i}" data-en="Meal Preference:" data-es="Preferencia de comida:">Preferencia de comida:</label>
                 <select id="guestMeal${i}" name="guestMeal${i}">
-                    <option value="" data-en="-- Please select --" data-hi="-- कृपया चुनें --">-- Please select --</option>
-                    <option value="standard" data-en="🔴 Non-Veg (Chicken/Mutton)" data-hi="🔴 नॉन-वेज (चिकन/मटन)">🔴 Non-Veg (Chicken/Mutton)</option>
-                    <option value="vegetarian" data-en="🟢 Vegetarian" data-hi="🟢 शाकाहारी">🟢 Vegetarian</option>
+                    <option value="" data-en="-- Please select --" data-es="-- Por favor selecciona --">-- Por favor selecciona --</option>
+                    <option value="standard" data-en="🔴 Non-Veg (Chicken/Mutton)" data-es="🔴 No vegetariano (Pollo/Cordero)">🔴 No vegetariano (Pollo/Cordero)</option>
+                    <option value="vegetarian" data-en="🟢 Vegetarian" data-es="🟢 Vegetariano">🟢 Vegetariano</option>
                 </select>
             </div>
         `;


### PR DESCRIPTION
## Summary
- default site language is now Spanish with option to switch to English
- remove all previous Hindi translations and add Spanish equivalents
- update map toggle and form submission messages for Spanish

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688e5f03af9c83248e96f981878cd808