### PR TITLE
Add Spanish language support

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Muktika's 2nd Birthday Party!</title>
+    <title data-en="Muktika's 2nd Birthday Party!" data-hi="मुक्तिका का दूसरा जन्मदिन!" data-es="¡La fiesta del segundo cumpleaños de Muktika!">Muktika's 2nd Birthday Party!</title>
     <link rel="stylesheet" href="styles.css" />
 
     <!-- Favicon -->
@@ -46,6 +46,7 @@
         <h1
           data-en="Muktika's 2nd Birthday Party!"
           data-hi="मुक्तिका का दूसरा जन्मदिन!"
+          data-es="¡La fiesta del segundo cumpleaños de Muktika!"
         >
           Muktika's 2nd Birthday Party!
         </h1>
@@ -84,6 +85,7 @@
         <p
           data-en="Please join us to celebrate this special day!"
           data-hi="कृपया इस विशेष दिन को मनाने के लिए हमारे साथ जुड़ें!"
+          data-es="¡Únete a nosotros para celebrar este día tan especial!"
         >
           Please join us to celebrate this special day!
         </p>
@@ -91,23 +93,23 @@
       </header>
 
       <div class="event-details">
-        <h2 data-en="Party Details" data-hi="पार्टी विवरण">Party Details</h2>
+        <h2 data-en="Party Details" data-hi="पार्टी विवरण" data-es="Detalles de la fiesta">Party Details</h2>
         <p>
-          <strong data-en="Date:" data-hi="दिनांक:">Date:</strong> Monday, Mar
+          <strong data-en="Date:" data-hi="दिनांक:" data-es="Fecha:">Date:</strong> Monday, Mar
           24, 2025
         </p>
         <p>
-          <strong data-en="Time:" data-hi="समय:">Time:</strong> 6:30 PM - 10:00
+          <strong data-en="Time:" data-hi="समय:" data-es="Hora:">Time:</strong> 6:30 PM - 10:00
           PM
         </p>
         <p>
-          <strong data-en="Venue:" data-hi="स्थान:">Venue:</strong> R/o
+          <strong data-en="Venue:" data-hi="स्थान:" data-es="Lugar:">Venue:</strong> R/o
           Mr. Amar Sonker, ET - 1/A, Combined Hospital Campus, Cantt. Kanpur -
           208001 (Near Jhadi Baba Padav, Sahani Market)
         </p>
 
         <div class="map-container">
-          <h3 data-en="Location Map" data-hi="स्थान मानचित्र">Location Map</h3>
+          <h3 data-en="Location Map" data-hi="स्थान मानचित्र" data-es="Mapa de ubicación">Location Map</h3>
           <div class="map-wrapper">
             <iframe
               src="https://www.google.com/maps/embed?pb=!1m14!1m12!1m3!1d801.9511838133279!2d80.36721009649466!3d26.467277672967974!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!5e0!3m2!1sen!2sin!4v1742172448218!5m2!1sen!2sin"
@@ -126,12 +128,14 @@
               class="map-btn"
               data-en="Open in Google Maps"
               data-hi="Google मैप्स में खोलें"
+              data-es="Abrir en Google Maps"
               >Open in Google Maps</a
             >
             <button
               class="map-btn toggle-map"
               data-en="Hide Map"
               data-hi="मानचित्र छिपाएं"
+              data-es="Ocultar mapa"
             >
               Hide Map
             </button>
@@ -139,18 +143,19 @@
         </div>
 
         <p>
-          <strong data-en="Theme:" data-hi="थीम:">Theme:</strong> Unicorns
+          <strong data-en="Theme:" data-hi="थीम:" data-es="Tema:">Theme:</strong> Unicorns
         </p>
         <p
           data-en="Come join the fun as we celebrate with yummy treats, laughter, and wonderful family moments—let’s make sweet memories together!"
           data-hi="आइए, हम स्वादिष्ट व्यंजनों, हंसी-मजाक और अद्भुत पारिवारिक क्षणों के साथ जश्न मनाएं - आइए, साथ मिलकर मीठी यादें बनाएं!"
+          data-es="Únete a la diversión mientras celebramos con deliciosos bocadillos, risas y maravillosos momentos en familia. ¡Hagamos recuerdos dulces juntos!"
         >
         Come join the fun as we celebrate with yummy treats, laughter, and wonderful family moments—let’s make sweet memories together!
         </p>
       </div>
 
       <div class="form-container">
-        <h2 data-en="RSVP" data-hi="आर.एस.वी.पी.">RSVP</h2>
+        <h2 data-en="RSVP" data-hi="आर.एस.वी.पी." data-es="RSVP">RSVP</h2>
         <!-- <p
           data-en="Please let us know if you can attend by March 20th."
           data-hi="कृपया हमें 20 मार्च तक बताएं कि क्या आप आ सकते हैं।"
@@ -176,14 +181,14 @@
           />
 
           <div class="form-group">
-            <label for="name" data-en="Your Name:" data-hi="आपका नाम:"
+            <label for="name" data-en="Your Name:" data-hi="आपका नाम:" data-es="Tu nombre:"
               >Your Name:</label
             >
             <input type="text" id="name" name="name" required />
           </div>
 
           <div class="form-group">
-            <label data-en="Will you attend?" data-hi="क्या आप आएंगे?"
+            <label data-en="Will you attend?" data-hi="क्या आप आएंगे?" data-es="¿Asistirás?"
               >Will you attend?</label
             >
             <div class="radio-options">
@@ -199,6 +204,7 @@
                   for="attend-yes"
                   data-en="Yes, we'll be there!"
                   data-hi="हां, हम आएंगे!"
+                  data-es="¡Sí, estaremos allí!"
                   >Yes, we'll be there!</label
                 >
               </div>
@@ -213,6 +219,7 @@
                   for="attend-no"
                   data-en="Sorry, we can't make it"
                   data-hi="माफ़ करें, हम नहीं आ सकते"
+                  data-es="Lo sentimos, no podremos asistir"
                   >Sorry, we can't make it</label
                 >
               </div>
@@ -220,12 +227,13 @@
           </div>
 
           <div class="form-group">
-            <label
-              for="guests"
-              data-en="Number of guests (including yourself):"
-              data-hi="अतिथियों की संख्या (स्वयं सहित):"
-              >Number of guests (including yourself):</label
-            >
+              <label
+                for="guests"
+                data-en="Number of guests (including yourself):"
+                data-hi="अतिथियों की संख्या (स्वयं सहित):"
+                data-es="Número de invitados (incluyéndote):"
+                >Number of guests (including yourself):</label
+              >
             <input
               type="number"
               id="guests"
@@ -243,44 +251,48 @@
         <!-- Kids section removed as requested -->
 
           <div class="form-group">
-            <label
-              for="allergies"
-              data-en="Any allergies or dietary restrictions?"
-              data-hi="कोई एलर्जी या आहार संबंधी प्रतिबंध?"
-              >Any allergies or dietary restrictions?</label
-            >
+              <label
+                for="allergies"
+                data-en="Any allergies or dietary restrictions?"
+                data-hi="कोई एलर्जी या आहार संबंधी प्रतिबंध?"
+                data-es="¿Alguna alergia o restricción alimentaria?"
+                >Any allergies or dietary restrictions?</label
+              >
             <textarea id="allergies" name="allergies" rows="3"></textarea>
           </div>
 
           <div class="form-group">
-            <label
-              for="message"
-              data-en="Message for Muktika (optional):"
-              data-hi="मुक्तिका के लिए संदेश (वैकल्पिक):"
-              >Message for Muktika (optional):</label
-            >
+              <label
+                for="message"
+                data-en="Message for Muktika (optional):"
+                data-hi="मुक्तिका के लिए संदेश (वैकल्पिक):"
+                data-es="Mensaje para Muktika (opcional):"
+                >Message for Muktika (optional):</label
+              >
             <textarea id="message" name="message" rows="3"></textarea>
           </div>
 
-          <button
-            type="submit"
-            data-en="Submit RSVP"
-            data-hi="आर.एस.वी.पी. जमा करें"
-          >
-            Submit RSVP
-          </button>
+            <button
+              type="submit"
+              data-en="Submit RSVP"
+              data-hi="आर.एस.वी.पी. जमा करें"
+              data-es="Enviar RSVP"
+            >
+              Submit RSVP
+            </button>
 
         </form>
 
-        <div
-          id="successMessage"
-          class="success-message"
-          style="display: none"
-          data-en="Thank you for your response! We look forward to celebrating with you."
-          data-hi="आपके जवाब के लिए धन्यवाद! हम आपके साथ जश्न मनाने के लिए उत्सुक हैं।"
-        >
-          Thank you for your response! We look forward to celebrating with you.
-        </div>
+          <div
+            id="successMessage"
+            class="success-message"
+            style="display: none"
+            data-en="Thank you for your response! We look forward to celebrating with you."
+            data-hi="आपके जवाब के लिए धन्यवाद! हम आपके साथ जश्न मनाने के लिए उत्सुक हैं।"
+            data-es="¡Gracias por tu respuesta! Esperamos celebrar contigo."
+          >
+            Thank you for your response! We look forward to celebrating with you.
+          </div>
       </div>
     </div>
 

--- a/script.js
+++ b/script.js
@@ -1,18 +1,18 @@
 // Language toggle functionality
+const languages = ['en', 'hi', 'es'];
+const languageLabels = { en: 'English', hi: 'हिंदी', es: 'Español' };
 let currentLanguage = 'en';
 
 document.getElementById('toggleLanguage').addEventListener('click', function() {
-    if (currentLanguage === 'en') {
-        switchLanguage('hi');
-        this.textContent = 'English';
-    } else {
-        switchLanguage('en');
-        this.textContent = 'हिंदी';
-    }
+    const nextLang = languages[(languages.indexOf(currentLanguage) + 1) % languages.length];
+    switchLanguage(nextLang);
+    const nextLabel = languageLabels[languages[(languages.indexOf(nextLang) + 1) % languages.length]];
+    this.textContent = nextLabel;
 });
 
 function switchLanguage(lang) {
     currentLanguage = lang;
+    document.documentElement.lang = lang;
     const elements = document.querySelectorAll('[data-en]');
     
     elements.forEach(element => {
@@ -59,7 +59,11 @@ document.getElementById('rsvpForm').addEventListener('submit', function(event) {
     } else {
         // For initial form submission
         const submitButton = document.querySelector('button[type="submit"]');
-        submitButton.textContent = currentLanguage === 'en' ? 'Submitting...' : 'भेज रहा है...';
+        submitButton.textContent = currentLanguage === 'en'
+            ? 'Submitting...'
+            : currentLanguage === 'hi'
+            ? 'भेज रहा है...'
+            : 'Enviando...';
         submitButton.disabled = true;
         
         // Save local backup
@@ -147,8 +151,10 @@ document.addEventListener('DOMContentLoaded', function() {
 function updateMapToggleText(button, isCollapsed) {
     if (currentLanguage === 'en') {
         button.textContent = isCollapsed ? 'Show Map' : 'Hide Map';
-    } else {
+    } else if (currentLanguage === 'hi') {
         button.textContent = isCollapsed ? 'मानचित्र दिखाएं' : 'मानचित्र छिपाएं';
+    } else {
+        button.textContent = isCollapsed ? 'Mostrar mapa' : 'Ocultar mapa';
     }
 }
 
@@ -211,22 +217,22 @@ function generateGuestFields(count) {
         guestDiv.className = 'guest-detail';
         guestDiv.dataset.guestIndex = i;
         
-        const title = i === 1 ? 
-            `<h4 data-en="Guest ${i} (you)" data-hi="अतिथि ${i} (आप)">Guest ${i} (you)</h4>` : 
-            `<h4 data-en="Guest ${i}" data-hi="अतिथि ${i}">Guest ${i}</h4>`;
+        const title = i === 1 ?
+            `<h4 data-en="Guest ${i} (you)" data-hi="अतिथि ${i} (आप)" data-es="Invitado ${i} (tú)">Guest ${i} (you)</h4>` :
+            `<h4 data-en="Guest ${i}" data-hi="अतिथि ${i}" data-es="Invitado ${i}">Guest ${i}</h4>`;
         
         guestDiv.innerHTML = `
             ${title}
             <div class="form-group">
-                <label for="guestName${i}" data-en="Name:" data-hi="नाम:">Name:</label>
+                <label for="guestName${i}" data-en="Name:" data-hi="नाम:" data-es="Nombre:">Name:</label>
                 <input type="text" id="guestName${i}" name="guestName${i}" required>
             </div>
             <div class="form-group">
-                <label for="guestMeal${i}" data-en="Meal Preference:" data-hi="भोजन प्राथमिकता:">Meal Preference:</label>
+                <label for="guestMeal${i}" data-en="Meal Preference:" data-hi="भोजन प्राथमिकता:" data-es="Preferencia de comida:">Meal Preference:</label>
                 <select id="guestMeal${i}" name="guestMeal${i}">
-                    <option value="" data-en="-- Please select --" data-hi="-- कृपया चुनें --">-- Please select --</option>
-                    <option value="standard" data-en="🔴 Non-Veg (Chicken/Mutton)" data-hi="🔴 नॉन-वेज (चिकन/मटन)">🔴 Non-Veg (Chicken/Mutton)</option>
-                    <option value="vegetarian" data-en="🟢 Vegetarian" data-hi="🟢 शाकाहारी">🟢 Vegetarian</option>
+                    <option value="" data-en="-- Please select --" data-hi="-- कृपया चुनें --" data-es="-- Por favor selecciona --">-- Please select --</option>
+                    <option value="standard" data-en="🔴 Non-Veg (Chicken/Mutton)" data-hi="🔴 नॉन-वेज (चिकन/मटन)" data-es="🔴 No vegetariano (pollo/cordero)">🔴 Non-Veg (Chicken/Mutton)</option>
+                    <option value="vegetarian" data-en="🟢 Vegetarian" data-hi="🟢 शाकाहारी" data-es="🟢 Vegetariano">🟢 Vegetarian</option>
                 </select>
             </div>
         `;


### PR DESCRIPTION
## Summary
- add Spanish translations for site content and RSVP form
- allow switching among English, Hindi, and Spanish

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ebfa8ff148324927c5e986723a4ad