### PR TITLE
feat: add 12-hour time format and music control

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <meta property="og:url" content="https://shubhshackyard.github.io/birthdayInvitation" />
   </head>
   <body>
-    <audio id="backgroundMusic" src="media/background-music.mp3" loop></audio>
+    <audio id="backgroundMusic" src="media/background-music.mp3" loop autoplay></audio>
     <div class="container">
       <div class="language-toggle">
         <button id="toggleLanguage" class="lang-btn">English</button>

--- a/script.js
+++ b/script.js
@@ -166,24 +166,29 @@ document.addEventListener('DOMContentLoaded', function() {
     if (music) {
         const btn = document.createElement('button');
         btn.id = 'musicToggle';
-        btn.textContent = '🔊';
+
+        const updateIcon = () => {
+            btn.textContent = music.paused ? '🔇' : '🔊';
+        };
+
         btn.addEventListener('click', () => {
             if (music.paused) {
-                music.play();
-                btn.textContent = '🔊';
+                music.play().catch(() => {});
             } else {
                 music.pause();
-                btn.textContent = '🔇';
             }
+            updateIcon();
         });
+
         document.body.appendChild(btn);
 
-        const playPromise = music.play();
-        if (playPromise !== undefined) {
-            playPromise.catch(() => {
-                btn.textContent = '🔇';
-            });
-        }
+        const attemptPlay = () => {
+            music.play().catch(() => {});
+            updateIcon();
+        };
+
+        attemptPlay();
+        window.addEventListener('load', attemptPlay);
     }
 });
 

--- a/script.js
+++ b/script.js
@@ -21,9 +21,17 @@ function formatDate(date, lang) {
     });
 }
 
-function formatTime(start, end, lang) {
-    const opts = { hour: 'numeric', minute: '2-digit' };
-    return `${start.toLocaleTimeString(lang, opts)} - ${end.toLocaleTimeString(lang, opts)}`;
+function to12Hour(date) {
+    let hours = date.getHours();
+    const minutes = date.getMinutes().toString().padStart(2, '0');
+    const ampm = hours >= 12 ? 'PM' : 'AM';
+    hours = hours % 12;
+    hours = hours ? hours : 12; // the hour '0' should be '12'
+    return `${hours}:${minutes} ${ampm}`;
+}
+
+function formatTime(start, end) {
+    return `${to12Hour(start)} - ${to12Hour(end)}`;
 }
 
 function updateEventInfo() {
@@ -31,7 +39,7 @@ function updateEventInfo() {
     const timeEl = document.getElementById('eventTime');
     const locale = currentLanguage === 'en' ? 'en-US' : 'es-ES';
     if (dateEl) dateEl.textContent = formatDate(eventStart, locale);
-    if (timeEl) timeEl.textContent = formatTime(eventStart, eventEnd, locale);
+    if (timeEl) timeEl.textContent = formatTime(eventStart, eventEnd);
 }
 
 function applyConfiguration() {
@@ -156,19 +164,24 @@ document.addEventListener('DOMContentLoaded', function() {
 
     const music = document.getElementById('backgroundMusic');
     if (music) {
+        const btn = document.createElement('button');
+        btn.id = 'musicToggle';
+        btn.textContent = '🔊';
+        btn.addEventListener('click', () => {
+            if (music.paused) {
+                music.play();
+                btn.textContent = '🔊';
+            } else {
+                music.pause();
+                btn.textContent = '🔇';
+            }
+        });
+        document.body.appendChild(btn);
+
         const playPromise = music.play();
         if (playPromise !== undefined) {
             playPromise.catch(() => {
-                const btn = document.createElement('button');
-                btn.id = 'musicToggle';
-                btn.setAttribute('data-en', 'Play Music');
-                btn.setAttribute('data-es', 'Reproducir música');
-                btn.textContent = currentLanguage === 'en' ? 'Play Music' : 'Reproducir música';
-                btn.addEventListener('click', () => {
-                    music.play();
-                    btn.remove();
-                });
-                document.body.appendChild(btn);
+                btn.textContent = '🔇';
             });
         }
     }

--- a/styles.css
+++ b/styles.css
@@ -75,6 +75,27 @@ body {
     transform: scale(1.05) rotate(-2deg);
 }
 
+/* Floating music toggle button */
+#musicToggle {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: var(--secondary-color);
+    color: white;
+    border: none;
+    border-radius: 50%;
+    width: 50px;
+    height: 50px;
+    font-size: 1.2rem;
+    cursor: pointer;
+    z-index: 1000;
+    box-shadow: 0 3px 10px rgba(0,0,0,0.2);
+}
+
+#musicToggle:hover {
+    background-color: var(--primary-color);
+}
+
 /* Header styles */
 header {
     text-align: center;


### PR DESCRIPTION
## Summary
- display event time in consistent 12-hour format with AM/PM
- autoplay background music with floating toggle button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688ecae4de4c8324915fe1daf0e409e3