### PR TITLE
Add Open Graph metadata for social preview

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title id="pageTitle"></title>
+    <title id="pageTitle">¡Fiesta del 60º cumpleaños de Marita!</title>
     <link rel="stylesheet" href="styles.css" />
 
     <!-- Favicon -->
@@ -27,13 +27,38 @@
     <link rel="manifest" href="media/site.webmanifest" />
 
     <!-- Social Media Sharing -->
-    <meta id="ogTitle" property="og:title" content="" />
+    <meta
+      id="ogTitle"
+      property="og:title"
+      content="¡Fiesta del 60º cumpleaños de Marita!"
+    />
+    <meta
+      name="description"
+      content="¡Únete a nosotros para celebrar este día tan especial!"
+    />
     <meta
       property="og:description"
       content="¡Únete a nosotros para celebrar este día tan especial!"
     />
-    <meta property="og:image" content="media/og-image.jpg" />
-    <meta property="og:url" content="https://shubhshackyard.github.io/birthdayInvitation" />
+    <meta
+      property="og:image"
+      content="https://shubhshackyard.github.io/birthdayInvitation/media/og-image.jpg"
+    />
+    <meta
+      property="og:url"
+      content="https://shubhshackyard.github.io/birthdayInvitation/"
+    />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="¡Fiesta del 60º cumpleaños de Marita!" />
+    <meta
+      name="twitter:description"
+      content="¡Únete a nosotros para celebrar este día tan especial!"
+    />
+    <meta
+      name="twitter:image"
+      content="https://shubhshackyard.github.io/birthdayInvitation/media/og-image.jpg"
+    />
   </head>
   <body>
     <audio id="backgroundMusic" src="media/background-music.mp3" loop autoplay></audio>


### PR DESCRIPTION
## Summary
- add Open Graph, Twitter Card, and meta description tags
- give page a default title and absolute image URL for sharing

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/birthdayInvitation/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_688f6c4087288324b10f93c9ca7f0ead