### PR TITLE
Add link preview metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,6 @@
     <!-- Social Media Sharing -->
     <meta property="og:type" content="website" />
     <meta
-      id="ogTitle"
       property="og:title"
       content="¡Fiesta de cumpleaños de Marita por sus 60 años!"
     />
@@ -39,11 +38,15 @@
     />
     <meta
       property="og:image"
-      content="media/video-placeholder.jpg"
+      content="https://shubhshackyard.github.io/birthdayInvitation/media/video-placeholder.jpg"
     />
     <meta
       property="og:url"
       content="https://shubhshackyard.github.io/birthdayInvitation"
+    />
+    <meta
+      property="og:site_name"
+      content="Invitación de Cumpleaños"
     />
     <meta name="twitter:card" content="summary_large_image" />
     <meta
@@ -54,7 +57,10 @@
       name="twitter:description"
       content="¡Únete a nosotros para celebrar este día tan especial!"
     />
-    <meta name="twitter:image" content="media/video-placeholder.jpg" />
+    <meta
+      name="twitter:image"
+      content="https://shubhshackyard.github.io/birthdayInvitation/media/video-placeholder.jpg"
+    />
   </head>
   <body>
     <audio id="backgroundMusic" src="media/background-music.mp3" loop autoplay></audio>

--- a/index.html
+++ b/index.html
@@ -27,13 +27,34 @@
     <link rel="manifest" href="media/site.webmanifest" />
 
     <!-- Social Media Sharing -->
-    <meta id="ogTitle" property="og:title" content="" />
+    <meta property="og:type" content="website" />
+    <meta
+      id="ogTitle"
+      property="og:title"
+      content="¡Fiesta de cumpleaños de Marita por sus 60 años!"
+    />
     <meta
       property="og:description"
       content="¡Únete a nosotros para celebrar este día tan especial!"
     />
-    <meta property="og:image" content="media/og-image.jpg" />
-    <meta property="og:url" content="https://shubhshackyard.github.io/birthdayInvitation" />
+    <meta
+      property="og:image"
+      content="media/video-placeholder.jpg"
+    />
+    <meta
+      property="og:url"
+      content="https://shubhshackyard.github.io/birthdayInvitation"
+    />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta
+      name="twitter:title"
+      content="¡Fiesta de cumpleaños de Marita por sus 60 años!"
+    />
+    <meta
+      name="twitter:description"
+      content="¡Únete a nosotros para celebrar este día tan especial!"
+    />
+    <meta name="twitter:image" content="media/video-placeholder.jpg" />
   </head>
   <body>
     <audio id="backgroundMusic" src="media/background-music.mp3" loop autoplay></audio>


### PR DESCRIPTION
## Summary
- add Open Graph and Twitter metadata for WhatsApp link previews using video placeholder image

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688fe550e9ac8324840121938411cb48