### PR TITLE
Limit vertical video width to 50%

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -366,6 +366,7 @@ header p {
 .video-container {
     position: relative;
     max-width: 650px;
+    width: 50%;
     margin: 0 auto;
     border-radius: 12px;
     overflow: hidden;
@@ -378,7 +379,7 @@ header p {
     display: block;
     width: 100%;
     height: auto;
-    object-fit: cover;
+    object-fit: contain;
     transition: opacity 0.3s ease;
 }
 
@@ -425,6 +426,7 @@ header p {
 @media screen and (max-width: 768px) {
     .video-container {
         max-width: 100%;
+        width: 100%;
         border-radius: 8px;
     }
 }


### PR DESCRIPTION
## Summary
- Limit video container width to 50% to shrink vertical video
- Use `object-fit: contain` and responsive rules for small screens

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689014f6e9248324852ff1cd9935278a