### PR TITLE
feat: add floating language switch

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
   </head>
   <body>
     <audio id="backgroundMusic" src="media/background-music.mp3" loop autoplay></audio>
-    <button id="toggleLanguage" class="lang-btn">EN</button>
+    <button id="toggleLanguage" class="lang-btn fancy-btn floating-btn">EN</button>
     <div class="container">
 
       <header>
@@ -305,6 +305,7 @@
 
           <button
             type="submit"
+            class="fancy-btn"
             data-en="Submit RSVP"
             data-es="Enviar RSVP"
           >

--- a/index.html
+++ b/index.html
@@ -64,10 +64,8 @@
   </head>
   <body>
     <audio id="backgroundMusic" src="media/background-music.mp3" loop autoplay></audio>
+    <button id="toggleLanguage" class="lang-btn">EN</button>
     <div class="container">
-      <div class="language-toggle">
-        <button id="toggleLanguage" class="lang-btn">English</button>
-      </div>
 
       <header>
         <div class="balloons">🎈🎀🎈</div>

--- a/script.js
+++ b/script.js
@@ -77,10 +77,10 @@ let currentLanguage = 'es';
 document.getElementById('toggleLanguage').addEventListener('click', function() {
     if (currentLanguage === 'es') {
         switchLanguage('en');
-        this.textContent = 'Español';
+        this.textContent = 'ES';
     } else {
         switchLanguage('es');
-        this.textContent = 'English';
+        this.textContent = 'EN';
     }
 });
 

--- a/script.js
+++ b/script.js
@@ -161,6 +161,7 @@ document.addEventListener('DOMContentLoaded', function() {
     if (music) {
         const btn = document.createElement('button');
         btn.id = 'musicToggle';
+        btn.className = 'fancy-btn floating-btn';
         btn.textContent = '🔊';
         btn.addEventListener('click', () => {
             if (music.paused) {

--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,10 @@
     --dark-text: #4F3A65; /* Dark Purple Text */
 }
 
+html {
+    scroll-behavior: smooth;
+}
+
 * {
     box-sizing: border-box;
     transition: all 0.3s ease;
@@ -31,12 +35,13 @@ body {
     background-color: white;
     padding: 30px;
     border-radius: 20px;
-    box-shadow: 
+    box-shadow:
         0 10px 30px rgba(123, 91, 230, 0.2),
         0 0 0 15px rgba(255, 97, 166, 0.1),
         0 0 0 30px rgba(255, 209, 102, 0.05);
     position: relative;
     overflow: hidden;
+    animation: fadeIn 1s ease-in;
 }
 
 /* Add a wavy border to the container */
@@ -51,6 +56,8 @@ body {
     background-size: 24px 24px;
 }
 
+
+/* Base styling for circular language button */
 .lang-btn {
     background-color: var(--secondary-color);
     color: white;
@@ -65,8 +72,8 @@ body {
 }
 
 .lang-btn:hover {
-    background-color: var(--primary-color);
     transform: scale(1.05) rotate(-2deg);
+    filter: brightness(1.1);
 }
 
 /* Floating language toggle button */
@@ -85,8 +92,7 @@ body {
 }
 
 #toggleLanguage:hover {
-    background-color: var(--primary-color);
-    transform: none;
+    filter: brightness(1.1);
 }
 
 /* Floating music toggle button */
@@ -94,7 +100,6 @@ body {
     position: fixed;
     bottom: 20px;
     right: 20px;
-    background-color: var(--secondary-color);
     color: white;
     border: none;
     border-radius: 50%;
@@ -106,8 +111,32 @@ body {
     box-shadow: 0 3px 10px rgba(0,0,0,0.2);
 }
 
-#musicToggle:hover {
-    background-color: var(--primary-color);
+/* Shared fancy button styling */
+.fancy-btn {
+    background: linear-gradient(135deg, var(--secondary-color), var(--primary-color));
+    border: 3px solid var(--accent1);
+    box-shadow: 0 0 15px rgba(123, 91, 230, 0.6);
+    color: white;
+    cursor: pointer;
+}
+
+.fancy-btn:hover {
+    transform: scale(1.1) rotate(5deg);
+    box-shadow: 0 0 20px rgba(255, 209, 102, 0.8);
+}
+
+.floating-btn {
+    animation: float 3s ease-in-out infinite;
+}
+
+@keyframes float {
+    0%, 100% { transform: translateY(0); }
+    50% { transform: translateY(-5px); }
+}
+
+@keyframes fadeIn {
+    from { opacity: 0; transform: translateY(20px); }
+    to { opacity: 1; transform: translateY(0); }
 }
 
 /* Header styles */

--- a/styles.css
+++ b/styles.css
@@ -51,12 +51,6 @@ body {
     background-size: 24px 24px;
 }
 
-/* Language Toggle */
-.language-toggle {
-    text-align: right;
-    margin-bottom: 20px;
-}
-
 .lang-btn {
     background-color: var(--secondary-color);
     color: white;
@@ -73,6 +67,26 @@ body {
 .lang-btn:hover {
     background-color: var(--primary-color);
     transform: scale(1.05) rotate(-2deg);
+}
+
+/* Floating language toggle button */
+#toggleLanguage {
+    position: fixed;
+    bottom: 80px;
+    right: 20px;
+    width: 50px;
+    height: 50px;
+    padding: 0;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 1000;
+}
+
+#toggleLanguage:hover {
+    background-color: var(--primary-color);
+    transform: none;
 }
 
 /* Floating music toggle button */


### PR DESCRIPTION
## Summary
- add circular floating button to toggle language between ES/EN
- adjust styles for floating language toggle above music control
- shorten language toggle labels to two letters

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6891155459208324aea10c4ec826368c